### PR TITLE
Add Revit 2022 support

### DIFF
--- a/CPI Sheets Updater/CPI Sheets Updater/CPI Sheets Updater.csproj
+++ b/CPI Sheets Updater/CPI Sheets Updater/CPI Sheets Updater.csproj
@@ -12,6 +12,7 @@
     <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION
Bodge spec name instead of normal fix. Need to move to the multiversion compilation, but don't want yet